### PR TITLE
fix compilation for Mojave

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export MACOSX_DEPLOYMENT_TARGET=10.6
 #export ARCHS=-arch i386 -arch x86_64 -arch ppc
-export SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+export SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 export WARNINGS=-Wall -Wmost -Wextra -Wno-missing-braces  -Wno-private-extern -Werror
 export CFLAGS=-g -isysroot $(SYSROOT) $(WARNINGS) #-DNDEBUG
 export LFLAGS=-g -isysroot $(SYSROOT)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-export MACOSX_DEPLOYMENT_TARGET=10.5
+export MACOSX_DEPLOYMENT_TARGET=10.6
 #export ARCHS=-arch i386 -arch x86_64 -arch ppc
-export SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
+export SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
 export WARNINGS=-Wall -Wmost -Wextra -Wno-missing-braces  -Wno-private-extern -Werror
 export CFLAGS=-g -isysroot $(SYSROOT) $(WARNINGS) #-DNDEBUG
 export LFLAGS=-g -isysroot $(SYSROOT)


### PR DESCRIPTION
This fixes a compilation for OS X Mojave. Perhaps a PEBKAC, but OS X wasn't able to find the right 9p driver--there was already one existing at /sbin/mount_9p. It looks pretty crippled, so I tried running the installed mount_9p under /Library/, but that had trouble finding load_9p, even tho' the file existed at the location listed in the error message. I ended up installing plan9port and using 9pfuse instead.